### PR TITLE
Fix heading hierarchy on Research and Policy Analysis pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,7 @@
 }
 
 .section h2 {
-  font-size: 2.5rem;
+  font-size: 2rem;
   color: #319795;
   margin-bottom: 2rem;
   text-align: center;
@@ -118,7 +118,7 @@
   }
 
   .section h2 {
-    font-size: 1.8rem;
+    font-size: 1.5rem;
   }
 
   .section h3 {
@@ -157,7 +157,7 @@
   }
 
   .section h2 {
-    font-size: 1.6rem;
+    font-size: 1.3rem;
   }
 
   .section h3 {

--- a/src/components/PolicyScenarios.css
+++ b/src/components/PolicyScenarios.css
@@ -10,7 +10,7 @@
 }
 
 .section-header h2 {
-  font-size: 2.5rem;
+  font-size: 2rem;
   color: #319795;
   margin-bottom: 1rem;
 }
@@ -140,7 +140,7 @@
   }
 
   .section-header h2 {
-    font-size: 1.8rem;
+    font-size: 1.5rem;
   }
 
   .section-subtitle {
@@ -208,7 +208,7 @@
   }
 
   .section-header h2 {
-    font-size: 1.6rem;
+    font-size: 1.3rem;
   }
 
   .section-subtitle {

--- a/src/pages/PolicyAnalysis.js
+++ b/src/pages/PolicyAnalysis.js
@@ -6,7 +6,13 @@ function PolicyAnalysis() {
   return (
     <>
       <div className="section section-alt" style={{ paddingTop: "6rem" }}>
-        <h1 style={{ textAlign: "center", marginBottom: "1rem" }}>
+        <h1
+          style={{
+            textAlign: "center",
+            marginBottom: "1rem",
+            fontSize: "3rem",
+          }}
+        >
           Policy Analysis Framework
         </h1>
         <p

--- a/src/pages/Research.js
+++ b/src/pages/Research.js
@@ -8,7 +8,13 @@ function ResearchPage() {
   return (
     <>
       <div className="section section-alt" style={{ paddingTop: "6rem" }}>
-        <h1 style={{ textAlign: "center", marginBottom: "1rem" }}>
+        <h1
+          style={{
+            textAlign: "center",
+            marginBottom: "1rem",
+            fontSize: "3rem",
+          }}
+        >
           Research Context
         </h1>
         <p


### PR DESCRIPTION
## Summary
- Fix visual hierarchy where h2 section headings appeared larger than h1 page titles
- Set h1 to 3rem and reduce h2 from 2.5rem to 2rem
- Update all responsive breakpoints to maintain proper hierarchy

## Changes
- `src/pages/Research.js`: Add explicit 3rem font-size to h1
- `src/pages/PolicyAnalysis.js`: Add explicit 3rem font-size to h1  
- `src/App.css`: Reduce `.section h2` from 2.5rem to 2rem (and responsive sizes)
- `src/components/PolicyScenarios.css`: Reduce `.section-header h2` from 2.5rem to 2rem (and responsive sizes)

## Test plan
- [x] View Research page - "Research Context" larger than "Relevant Research"
- [x] View Policy Analysis page - "Policy Analysis Framework" larger than "Alternative Policy Interventions"
- [x] Check responsive breakpoints maintain hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)