### PR TITLE
Move uprating viewer to Policy Analysis page as expandable

### DIFF
--- a/src/components/PolicyEngineCapabilities.css
+++ b/src/components/PolicyEngineCapabilities.css
@@ -113,6 +113,29 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
+.uprating-section {
+  margin-top: 2rem;
+}
+
+.uprating-toggle {
+  width: 100%;
+  padding: 1rem 1.5rem;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+  color: #2c5f7c;
+}
+
+.uprating-toggle:hover {
+  background: #e8f0f5;
+  border-color: #2c5f7c;
+}
+
 @media (max-width: 768px) {
   .capabilities-section {
     padding: 3rem 1.25rem;

--- a/src/components/PolicyEngineCapabilities.js
+++ b/src/components/PolicyEngineCapabilities.js
@@ -1,7 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
+import UpratingViewer from "./UpratingViewer";
 import "./PolicyEngineCapabilities.css";
 
 function PolicyEngineCapabilities() {
+  const [showUprating, setShowUprating] = useState(false);
+
   const capabilities = [
     {
       title: "Open-Source Microsimulation",
@@ -88,6 +91,16 @@ function PolicyEngineCapabilities() {
               </a>
             </div>
           </div>
+        </div>
+
+        <div className="uprating-section">
+          <button
+            onClick={() => setShowUprating(!showUprating)}
+            className="uprating-toggle"
+          >
+            {showUprating ? "▼" : "▶"} Interactive Uprating Explorer
+          </button>
+          {showUprating && <UpratingViewer />}
         </div>
       </div>
     </div>

--- a/src/pages/Research.js
+++ b/src/pages/Research.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Research from "../components/Research";
 import StochasticForecasting from "../components/StochasticForecasting";
-import UpratingViewer from "../components/UpratingViewer";
 import TechnicalRequirements from "../components/TechnicalRequirements";
 
 function ResearchPage() {
@@ -31,7 +30,6 @@ function ResearchPage() {
       </div>
       <Research />
       <StochasticForecasting />
-      <UpratingViewer />
       <TechnicalRequirements />
       <div
         className="section"


### PR DESCRIPTION
## Summary

Moves the interactive uprating viewer from the Research page to the Policy Analysis page, positioned as an expandable section below the open-source box.

## Changes

- Add UpratingViewer as collapsible section in PolicyEngineCapabilities component
- Remove UpratingViewer from Research page
- Add expandable toggle button with arrow indicator (▶/▼)
- Clean, minimal expandable UI matching site design

## UX Improvement

- Better organization: uprating analysis belongs with policy analysis tools
- Reduces initial page length - content expands on demand
- Cleaner Research page focused on academic context

🤖 Generated with [Claude Code](https://claude.com/claude-code)