### PR TITLE
Move uprating viewer to Research page below uprating parameters

### DIFF
--- a/src/components/PolicyEngineCapabilities.css
+++ b/src/components/PolicyEngineCapabilities.css
@@ -113,29 +113,6 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-.uprating-section {
-  margin-top: 2rem;
-}
-
-.uprating-toggle {
-  width: 100%;
-  padding: 1rem 1.5rem;
-  background: #f5f5f5;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-size: 1.1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  text-align: left;
-  color: #2c5f7c;
-}
-
-.uprating-toggle:hover {
-  background: #e8f0f5;
-  border-color: #2c5f7c;
-}
-
 @media (max-width: 768px) {
   .capabilities-section {
     padding: 3rem 1.25rem;

--- a/src/components/PolicyEngineCapabilities.js
+++ b/src/components/PolicyEngineCapabilities.js
@@ -1,10 +1,7 @@
-import React, { useState } from "react";
-import UpratingViewer from "./UpratingViewer";
+import React from "react";
 import "./PolicyEngineCapabilities.css";
 
 function PolicyEngineCapabilities() {
-  const [showUprating, setShowUprating] = useState(false);
-
   const capabilities = [
     {
       title: "Open-Source Microsimulation",
@@ -91,16 +88,6 @@ function PolicyEngineCapabilities() {
               </a>
             </div>
           </div>
-        </div>
-
-        <div className="uprating-section">
-          <button
-            onClick={() => setShowUprating(!showUprating)}
-            className="uprating-toggle"
-          >
-            {showUprating ? "▼" : "▶"} Interactive Uprating Explorer
-          </button>
-          {showUprating && <UpratingViewer />}
         </div>
       </div>
     </div>

--- a/src/components/StochasticForecasting.js
+++ b/src/components/StochasticForecasting.js
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
+import UpratingViewer from "./UpratingViewer";
 
 function StochasticForecasting() {
   const [expandedCard, setExpandedCard] = useState(null);
+  const [showUpratingViewer, setShowUpratingViewer] = useState(false);
 
   const upratingCategories = [
     {
@@ -198,6 +200,32 @@ function StochasticForecasting() {
             )}
           </div>
         ))}
+      </div>
+
+      <div style={{ marginTop: "2rem", marginBottom: "3rem" }}>
+        <button
+          onClick={() => setShowUpratingViewer(!showUpratingViewer)}
+          style={{
+            width: "100%",
+            padding: "1rem 1.5rem",
+            background: "#f0f9ff",
+            border: "2px solid #319795",
+            borderRadius: "8px",
+            fontSize: "1.1rem",
+            fontWeight: "600",
+            cursor: "pointer",
+            transition: "all 0.2s",
+            textAlign: "left",
+            color: "#319795",
+          }}
+        >
+          {showUpratingViewer ? "▼" : "▶"} Interactive Uprating Explorer
+        </button>
+        {showUpratingViewer && (
+          <div style={{ marginTop: "2rem" }}>
+            <UpratingViewer />
+          </div>
+        )}
       </div>
 
       <h3 style={{ marginTop: "3rem" }}>Probabilistic Forecast Data Sources</h3>


### PR DESCRIPTION
## Summary

Moves the Interactive Uprating Explorer to the Research page, positioned as an expandable section immediately after the uprating categories explanation.

## Changes

- Add UpratingViewer as collapsible section in StochasticForecasting component
- Position after "Uprating Parameters in PolicyEngine-US" grid
- Remove from PolicyEngineCapabilities (Policy Analysis page)
- Clean up unused CSS

## Better Organization

**Before**: Uprating concept explained on Research page, viewer on Policy Analysis page  
**After**: Concept and exploration tool are together on Research page

**Flow**: Explain 318 parameters → Show categories → Explore interactive data → Discuss modeling methods

This keeps all uprating-related content cohesive and improves user understanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)