### PR TITLE
Make 'AI Growth Research' title clickable to navigate home

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -42,10 +42,20 @@
   font-weight: 300;
 }
 
+.header-title-link {
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+.header-title-link:hover {
+  opacity: 0.8;
+}
+
 .header-title {
   color: white;
   font-weight: 600;
   font-size: 1rem;
+  cursor: pointer;
 }
 
 .header-nav {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -17,7 +17,9 @@ function Header() {
             />
           </a>
           <span className="header-divider">|</span>
-          <span className="header-title">AI Growth Research</span>
+          <Link to="/" className="header-title-link">
+            <span className="header-title">AI Growth Research</span>
+          </Link>
         </div>
 
         <nav className="header-nav">


### PR DESCRIPTION
## Summary

Makes the "AI Growth Research" text in the header clickable to navigate back to the home page.

## Changes

- Wrap header title in Link component pointing to "/"
- Add hover effect (slight opacity change) to indicate clickability
- Add cursor pointer for better UX

## UX Improvement

Common web pattern - site title links to home page. Makes navigation more intuitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)