### PR TITLE
Simplify hero subtitle from detailed distribution list to 'inequality'

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -7,9 +7,7 @@ function Hero() {
       <div className="hero-content">
         <h1>AI and Distributional Policy Research</h1>
         <p className="hero-subtitle">
-          How do economic policies mediate AI's impact
-          <br />
-          on income, consumption, and wealth distribution?
+          How do economic policies mediate AI's impact on inequality?
         </p>
         <p className="hero-description">
           A PolicyEngine research initiative examining how policy interventions


### PR DESCRIPTION
## Summary

Simplifies the hero subtitle for better readability and conciseness.

## Change

**Before**: "How do economic policies mediate AI's impact on income, consumption, and wealth distribution?"  
**After**: "How do economic policies mediate AI's impact on inequality?"

## Improvement

- More concise and readable
- Single-line instead of two lines
- "Inequality" captures the essence of income/consumption/wealth distribution
- Less awkward phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)