### PR TITLE
Update Node.js to 24 LTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Update Node.js to 24.x (Active LTS - Krypton).

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)