### PR TITLE
Make PUBLIC_URL dynamic and add post-deploy smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          PUBLIC_URL: /ai-inequality
+          PUBLIC_URL: /${{ github.event.repository.name }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -87,3 +87,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Smoke test deployed site
+        run: |
+          sleep 30
+          URL="https://policyengine.github.io/${{ github.event.repository.name }}/"
+          STATUS=$(curl -s -o /tmp/page.html -w "%{http_code}" "$URL")
+          if [ "$STATUS" != "200" ]; then
+            echo "ERROR: Site returned $STATUS"
+            exit 1
+          fi
+          if ! grep -q "/${{ github.event.repository.name }}/static/" /tmp/page.html; then
+            echo "ERROR: Asset paths don't match repo name"
+            cat /tmp/page.html
+            exit 1
+          fi
+          echo "Smoke test passed: $URL returned 200 with correct asset paths"


### PR DESCRIPTION
## Summary
- Replace hardcoded `PUBLIC_URL: /ai-inequality` with `PUBLIC_URL: /${{ github.event.repository.name }}` so the build path automatically tracks the repo name if it is ever renamed again (the repo was already renamed once from `ai-growth-research` to `ai-inequality`, requiring commit 9e5659a to fix).
- Add a post-deploy smoke test step that waits 30 seconds, then curls the live GitHub Pages site to verify it returns HTTP 200 and that the HTML references JS bundles under the correct `/<repo-name>/static/` path.

## Test plan
- [ ] Merge to main and verify the deploy workflow runs successfully, including the new smoke test step
- [ ] Confirm the build uses the correct `PUBLIC_URL` by checking the workflow logs for the Build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)