### PR TITLE
Link to PolicyEngine's model documentation

### DIFF
--- a/src/components/Ecosystem.js
+++ b/src/components/Ecosystem.js
@@ -118,7 +118,7 @@ function Ecosystem() {
         {
           name: "PolicyEngine",
           desc: "Open-source microsimulation for US, UK, Canada. This project.",
-          url: "https://policyengine.org",
+          url: "https://policyengine.org/us/model",
         },
         {
           name: "OG-USA (DeBacker & Evans)",

--- a/src/components/PolicyEngineCapabilities.js
+++ b/src/components/PolicyEngineCapabilities.js
@@ -93,6 +93,14 @@ function PolicyEngineCapabilities() {
               >
                 Read our research →
               </a>
+              <a
+                href="https://policyengine.org/us/model"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="capability-link"
+              >
+                Explore the model →
+              </a>
             </div>
           </div>
         </div>

--- a/src/components/Research.js
+++ b/src/components/Research.js
@@ -165,7 +165,7 @@ function Research() {
       links: [
         {
           text: "PolicyEngine US Model",
-          url: "https://policyengine.org/us",
+          url: "https://policyengine.org/us/model",
         },
         {
           text: "Tax Policy Center: Microsimulation Introduction",


### PR DESCRIPTION
## Summary
- Update "PolicyEngine US Model" link in the research section to point to `policyengine.org/us/model` instead of the generic `/us` page
- Update the PolicyEngine entry in the ecosystem "Models & tools" section to link to `policyengine.org/us/model`
- Add an "Explore the model" link in the capabilities section alongside existing links to AI features, GitHub, and research

## Test plan
- [ ] Verify all three links navigate to `https://policyengine.org/us/model`
- [ ] Confirm the new "Explore the model" link in the capabilities section renders correctly alongside existing links

🤖 Generated with [Claude Code](https://claude.com/claude-code)